### PR TITLE
mimetype changed to content_type and requirements list changed

### DIFF
--- a/django_evercookie/views.py
+++ b/django_evercookie/views.py
@@ -101,6 +101,6 @@ def evercookie_core(request):
         'auth_path': settings.auth_path,
         'domain': settings.domain,
         'static_url': settings.static_url},
-         mimetype="text/javascript")
+         content_type="text/javascript")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.4
-PIL==1.1.7
+Django>=1.5
+Pillow >= 2.0.0
 django-dont-vary-on==0.1.1


### PR DESCRIPTION
`Changed in Django 1.5: This parameter used to be called mimetype.`

I think we need to change `mimetype` to `content_type` in line 104 of `views.py` and change the `requirements.txt`
