### PR TITLE
Updated the module for newer Django versions (I used 1.10.3).

### DIFF
--- a/django_evercookie/config.py
+++ b/django_evercookie/config.py
@@ -1,36 +1,39 @@
+from __future__ import unicode_literals
 from django.conf import settings
 from django.contrib.sites.models import Site
 
 current_site = Site.objects.get_current()
 
+
 class Meta(type):
     def __init__(cls, *args, **kwargs):
         cls.instance = None
+
     def __call__(cls, *args, **kwargs):
         if cls.instance is None:
             cls.instance = super(Meta, cls).__call__(*args, **kwargs)
         return cls.instance
+
 
 class Settings(object):
     """Django Evercookie Settings Interface"""
     __metaclass__ = Meta
 
     def __init__(self, etag_cookie_name='etg',
-             etag_path='ecetag',
-             png_cookie_name='png',
-             png_path='epng',
-             cache_cookie_name='cachec',
-             cache_path='ecache',
-             history='false',
-             java='false',
-             silverlight='false',
-             domain='.'+current_site.domain,
-             tests=10,
-             base_url='',
-             auth_path='false',
-             static_url=settings.STATIC_URL + 'django_evercookie/',
-             cookie_value=''):
-
+                 etag_path='evercookie-ecetag',
+                 png_cookie_name='png',
+                 png_path='evercookie-epng',
+                 cache_cookie_name='cachec',
+                 cache_path='evercookie-ecache',
+                 history='false',
+                 java='false',
+                 silverlight='false',
+                 domain='.' + current_site.domain,
+                 tests=10,
+                 base_url='',
+                 auth_path='false',
+                 static_url=settings.STATIC_URL + 'django_evercookie/',
+                 cookie_value=''):
         self.etag_cookie_name = etag_cookie_name
         self.etag_path = etag_path
         self.png_cookie_name = png_cookie_name
@@ -51,5 +54,6 @@ class Settings(object):
         self.auth_path = auth_path
         self.static_url = static_url
         self.cookie_value = cookie_value
+
 
 settings = Settings()

--- a/django_evercookie/helpers.py
+++ b/django_evercookie/helpers.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from functools import wraps
 
 from django.http import HttpResponseNotModified

--- a/django_evercookie/templatetags/evercookie_js_api.py
+++ b/django_evercookie/templatetags/evercookie_js_api.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django import template
-
+from django.utils.html import format_html, mark_safe
 from django_evercookie.config import settings
 
 register = template.Library()
@@ -10,36 +10,48 @@ register = template.Library()
 
 @register.simple_tag
 def set_evercookie(ec_obj, name, value=None):
-    if value is None:
-        context_dict = {"ec_obj": ec_obj, "name": name, "value": settings.cookie_value}
-    else:
-        context_dict = {"ec_obj": ec_obj, "name": name, "value": value}
+    """
+    Creates an escaped script with the passed arguments and renders
+    them into the templates through the template tag.
+    :param ec_obj: The name of the JS-objects you want to create.
+    :param name: The name of the cookie you want to set.
+    :param value: The value (mostly a unique key) for the cookie.
+    :return:
+    """
+    script = "var {ec_obj}=new evercookie();{ec_obj}.set('{name}', '{value}');".format(
+        ec_obj=ec_obj,
+        name=name,
+        value=value or settings.cookie_value
+    )
+    return format_html(
+        "<script>{script}</script>",
+        script=mark_safe(script)
+    )
 
-    return '''<script>
-var %(ec_obj)s=new evercookie();
-%(ec_obj)s.set("%(name)s", "%(value)s");
-</script>''' % context_dict
 
-
-"""Cookies will be re-setted with best candidate"""
+"""Cookies will be re-initiated with best candidate"""
 
 
 @register.simple_tag
 def reactivate_evercookie(ec_obj, name):
     context_dict = {"ec_obj": ec_obj, "name": name}
 
-    return '''<script>
-    var %(ec_obj)s=new evercookie();
-    function getC(dont) {
-        %(ec_obj)s.get("%(name)s", function(best, all) {
-            for (var item in all)
-                 var payload = JSON.stringify({item: all});
-        if (!dont)
-            getC(1);
-    }, dont);
-}
-setTimeout(getC, 300);
-</script>''' % context_dict
+    script = """
+        var %(ec_obj)s=new evercookie();
+        function getC(dont) {
+            %(ec_obj)s.get("%(name)s", function(best, all) {
+                for (var item in all)
+                     var payload = JSON.stringify({item: all});
+            if (!dont)
+                getC(1);
+        }, dont);
+    }
+    setTimeout(getC, 300);
+    """ % context_dict
+    return format_html(
+        "<script>{script}</script>",
+        script=mark_safe(script)
+    )
 
 
 """Cookies won't be not re-setted"""
@@ -49,15 +61,19 @@ setTimeout(getC, 300);
 def rediscover_evercookie(ec_obj, name):
     context_dict = {"ec_obj": ec_obj, "name": name}
 
-    return '''<script>
-    var %(ec_obj)s=new evercookie();
-    function getC(dont) {
-        %(ec_obj)s.get("%(name)s", function(best, all) {
-            for (var item in all)
-                 var payload = JSON.stringify({item: all});
-        if (!dont)
-            getC(1);
-    }, dont);
-}
-setTimeout(getC, 300, 1);
-</script>''' % context_dict
+    script = """
+        var %(ec_obj)s=new evercookie();
+        function getC(dont) {
+            %(ec_obj)s.get("%(name)s", function(best, all) {
+                for (var item in all)
+                     var payload = JSON.stringify({item: all});
+            if (!dont)
+                getC(1);
+        }, dont);
+    }
+    setTimeout(getC, 300, 1);
+    """ % context_dict
+    return format_html(
+        "<script>{script}</script>",
+        script=mark_safe(script)
+    )

--- a/django_evercookie/templatetags/evercookie_js_api.py
+++ b/django_evercookie/templatetags/evercookie_js_api.py
@@ -1,11 +1,12 @@
+from __future__ import unicode_literals
 from django import template
-from django.core.urlresolvers import reverse
-from random import random
+
 from django_evercookie.config import settings
+
 register = template.Library()
 
-
 """Set evercookie"""
+
 
 @register.simple_tag
 def set_evercookie(ec_obj, name, value=None):
@@ -20,8 +21,8 @@ var %(ec_obj)s=new evercookie();
 </script>''' % context_dict
 
 
-
 """Cookies will be re-setted with best candidate"""
+
 
 @register.simple_tag
 def reactivate_evercookie(ec_obj, name):
@@ -40,7 +41,9 @@ def reactivate_evercookie(ec_obj, name):
 setTimeout(getC, 300);
 </script>''' % context_dict
 
+
 """Cookies won't be not re-setted"""
+
 
 @register.simple_tag
 def rediscover_evercookie(ec_obj, name):

--- a/django_evercookie/urls.py
+++ b/django_evercookie/urls.py
@@ -1,14 +1,13 @@
-try:
-    from django.conf.urls import url, patterns
-except ImportError:
-    from django.conf.urls.defaults import url, patterns
+from __future__ import unicode_literals
+from django.conf.urls import url
+from . import views
 
 """URLs differ from standart evercookie_<storage_method> to dodge easyprivacy blocking rules"""
 
-
-urlpatterns = patterns('django_evercookie.views',
-    url(r'^ecache', 'evercookie_cache', name='ecache'),
-    url(r'^epng', 'evercookie_png', name='epng'),
-    url(r'^ecetag', 'evercookie_etag', name='ecetag'),
-    url(r'^ecookie', 'evercookie_core', name='ecookie'),
-    url(r'^ecauth', 'evercookie_auth', name='ecauth'), )
+urlpatterns = [
+    url(r'^ecache/$', views.evercookie_cache, name='evercookie-ecache'),
+    url(r'^epng/$', views.evercookie_png, name='evercookie-epng'),
+    url(r'^ecetag/$', views.evercookie_etag, name='evercookie-ecetag'),
+    url(r'^ecookie/$', views.evercookie_core, name='evercookie-ecookie'),
+    url(r'^ecauth/$', views.evercookie_auth, name='evercookie-ecauth'),
+]

--- a/django_evercookie/views.py
+++ b/django_evercookie/views.py
@@ -1,21 +1,22 @@
- #-*- coding: utf-8 -*-
+# coding=utf-8
+from __future__ import unicode_literals
 
-from PIL import Image
 from StringIO import StringIO
 from copy import deepcopy
-from django_dont_vary_on.decorators import dont_vary_on
 
+from PIL import Image
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
-from django.core.urlresolvers import reverse
+from django_dont_vary_on.decorators import dont_vary_on
 
-from django_evercookie.helpers import cookie_exists
 from django_evercookie.config import settings
+from django_evercookie.helpers import cookie_exists
+
 
 @dont_vary_on('Cookie', 'Host')
 @cookie_exists(settings.cache_cookie_name)
 def evercookie_cache(request):
-
     cookie = request.COOKIES[settings.cache_cookie_name]
     response = HttpResponse(content=cookie, content_type='text/html; charset=UTF-8')
     response['Last-Modified'] = 'Wed, 30 Jun 2010 21:36:48 GMT'
@@ -25,9 +26,9 @@ def evercookie_cache(request):
 
     return response
 
+
 @dont_vary_on('Cookie', 'Host')
 def evercookie_etag(request):
-
     if settings.etag_cookie_name not in request.COOKIES:
         if 'HTTP_IF_NONE_MATCH' not in request.META:
             response = HttpResponse()
@@ -37,22 +38,25 @@ def evercookie_etag(request):
             response['Content-length'] = len(request.META['HTTP_IF_NONE_MATCH'])
 
     else:
-        response = HttpResponse(content=request.COOKIES[settings.etag_cookie_name], content_type='text/html; charset=UTF-8')
+        response = HttpResponse(
+            content=request.COOKIES[settings.etag_cookie_name],
+            content_type='text/html; charset=UTF-8'
+        )
         response['ETag'] = request.COOKIES[settings.etag_cookie_name]
         response['Content-length'] = len(request.COOKIES[settings.etag_cookie_name])
 
     return response
 
+
 @cookie_exists(settings.png_cookie_name)
 def evercookie_png(request):
-
     base_img = Image.new('RGB', (200, 1), color=None)
     cookie_value = list(request.COOKIES[settings.png_cookie_name])
     quotient, remainder = divmod(len(cookie_value), 3)
     new_cookie_value = deepcopy(cookie_value)
 
-    #php array returns null when index is out of range
-    #ugly python hack simulating that
+    # php array returns null when index is out of range
+    # ugly python hack simulating that
 
     if remainder == 1:
         new_cookie_value.extend(['\x00', '\x00'])
@@ -61,15 +65,15 @@ def evercookie_png(request):
 
     x_axis = 0
     y_axis = 0
-    index=0
+    index = 0
     buffer = StringIO()
 
     while index < len(new_cookie_value):
         base_img.putpixel((x_axis, y_axis), (ord(new_cookie_value[index]),
-                                           ord(new_cookie_value[index+1]),
-                                           ord(new_cookie_value[index+2])))
-        index+=3
-        x_axis+=1
+                                             ord(new_cookie_value[index + 1]),
+                                             ord(new_cookie_value[index + 2])))
+        index += 3
+        x_axis += 1
 
     base_img.save(buffer, 'PNG')
 
@@ -80,27 +84,26 @@ def evercookie_png(request):
 
     return response
 
+
 def evercookie_auth(request):
     """ Boilerplate view  """
     return HttpResponse()
 
+
 def evercookie_core(request):
-
     return render_to_response('evercookie.html',
-      {'history': settings.history,
-        'java': settings.java,
-        'tests': settings.tests,
-        'silverlight': settings.silverlight,
-        'base_url': settings.base_url,
-        'png_cookie_name': settings.png_cookie_name,
-        'png_path': reverse(settings.png_path),
-        'etag_cookie_name': settings.etag_cookie_name,
-        'etag_path': reverse(settings.etag_path),
-        'cache_cookie_name': settings.cache_cookie_name,
-        'cache_path': reverse(settings.cache_path),
-        'auth_path': settings.auth_path,
-        'domain': settings.domain,
-        'static_url': settings.static_url},
-         content_type="text/javascript")
-
-
+                              {'history': settings.history,
+                               'java': settings.java,
+                               'tests': settings.tests,
+                               'silverlight': settings.silverlight,
+                               'base_url': settings.base_url,
+                               'png_cookie_name': settings.png_cookie_name,
+                               'png_path': reverse(settings.png_path),
+                               'etag_cookie_name': settings.etag_cookie_name,
+                               'etag_path': reverse(settings.etag_path),
+                               'cache_cookie_name': settings.cache_cookie_name,
+                               'cache_path': reverse(settings.cache_path),
+                               'auth_path': settings.auth_path,
+                               'domain': settings.domain,
+                               'static_url': settings.static_url},
+                              content_type="text/javascript")


### PR DESCRIPTION
I changed the way the scripts are rendered into the template via the template tags.
Reason for that was to make use of the autoescape mechanism, as described in the documentation: 
https://docs.djangoproject.com/en/1.10/ref/utils/#module-django.utils.html
I also prefixed the reverse names of the Urls to make them fit to the application name.
Imports for newer python versions (__future__) were added, too.
I tested those changes for basic functionality.